### PR TITLE
Feature/SK-866 | Inference TaskType and keepalive args

### DIFF
--- a/rpc.cpp
+++ b/rpc.cpp
@@ -541,8 +541,17 @@ int main(int argc, char** argv) {
     host = proxy_host;
   }
   //Create a channel using the credentials created above
-  GrpcClient greeter(
-      grpc::CreateChannel(host, creds));
+  grpc::ChannelArguments args;
+  // Sample way of setting keepalive arguments on the client channel. Here we
+  // are configuring a keepalive time period of 20 seconds, with a timeout of 10
+  // seconds. Additionally, pings will be sent even if there are no calls in
+  // flight on an active connection.
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 20 * 1000 /*20 sec*/);
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10 * 1000 /*10 sec*/);
+  args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+  std::shared_ptr<ChannelInterface> channel = grpc::CreateCustomChannel(
+      host, creds, args);
+  GrpcClient greeter(channel);
   greeter.SayHello();
   greeter.ConnectModelUpdateStream();
   return 0;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -155,6 +155,10 @@ class GrpcClient {
         // TODO: Implement model validation
         std::cout << "Model validation not implemented, skipping..." << std::endl;
       }
+      else if (modelUpdate.type() == StatusType::INFERENCE) {
+        // TODO: Implement model inference
+        std::cout << "Model inference not implemented, skipping..." << std::endl;
+      }
       
     }
     reader->Finish();


### PR DESCRIPTION
Initial implementation of handling of Inference TaskType in stream. Adds keepalive configs for gRPC channel. Add interval and threading to Hearbeat (previously namned SayHello)