### PR TITLE
Feature/SK-951 | Add client_id for comp with fedn >=v0.11

### DIFF
--- a/http_client.cpp
+++ b/http_client.cpp
@@ -129,7 +129,8 @@ int main() {
     // Read requestData from the config
     json requestData;
     // Get client_id from the config
-    requestData["client_id"] = config["name"].as<std::string>();
+    requestData["client_id"] = config["client_id"].as<std::string>();
+    requestData["name"] = config["name"].as<std::string>();
 
     // Check if the client_id is valid
     if (!requestData["client_id"].is_string()) {

--- a/protos/fedn.proto
+++ b/protos/fedn.proto
@@ -147,6 +147,7 @@ enum Role {
 message Client {
   Role role = 1;
   string name = 2;
+  string client_id = 3;
 }
 
 message ReassignRequest {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -21,6 +21,7 @@
 // #include <mlpack.hpp>
 
 ABSL_FLAG(std::string, name, "test", "Name of client, (OBS! Must be same as used in http-client)");
+ABSL_FLAG(std::string, id, "test123", "ID of client");
 ABSL_FLAG(std::string, server_host, "localhost:12080", "Server host");
 ABSL_FLAG(std::string, proxy_host, "", "Proxy host");
 ABSL_FLAG(std::string, token, "", "Token for authentication");
@@ -97,6 +98,7 @@ class GrpcClient {
     Client* client = new Client();
     client->set_name(name_);
     client->set_role(WORKER);
+    client->set_client_id(id_);
 
     Heartbeat request;
     // Pass ownership of client to protobuf message
@@ -475,6 +477,7 @@ class GrpcClient {
   std::unique_ptr<Combiner::Stub> combinerStub_;
   std::unique_ptr<ModelService::Stub> modelserviceStub_;
   std::string name_ = absl::GetFlag(FLAGS_name);
+  std::string id_ = absl::GetFlag(FLAGS_id);
   static const size_t chunkSize = 1024 * 1024; // 1 MB, change this to suit your needs 
 };
 

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -134,6 +134,7 @@ class GrpcClient {
     Client* client = new Client();
     client->set_name(name_);
     client->set_role(WORKER);
+    client->set_client_id(id_);
 
     ClientAvailableMessage request;
     // Pass ownership of client to protobuf message
@@ -237,6 +238,7 @@ class GrpcClient {
       Client* client = new Client();
       client->set_name(name_);
       client->set_role(WORKER);
+      client->set_client_id(id_);
 
       // Get ClientWriter from stream
       std::unique_ptr<ClientWriter<ModelRequest> > writer(
@@ -410,6 +412,7 @@ class GrpcClient {
     Client client;
     client.set_name(name_);
     client.set_role(WORKER);
+    client.set_client_id(id_);
 
     
     ModelUpdate modelUpdate;


### PR DESCRIPTION
Related to fedn release v0.12 (latest), however only v0.11 had server changes.

Adds a unique client_id in addition to name (non-unique). Studio >=v0.13 will now generate a client_id in the downloaded client.yaml file. 

The c++ http_client make use of the client.yaml and thus the cleint_id in it.

The c++ grpc client, one has to provide the client_id via the flag "id". 