### PR TITLE
Feature/SK-1101 | Change HTTP protocol depending on insecure config

### DIFF
--- a/include/fednlib/fedn.h
+++ b/include/fednlib/fedn.h
@@ -25,6 +25,8 @@ public:
 
     void setAuthScheme(std::string authScheme);
     void setCombinerHost(std::string host);
+    void setInsecureCombiner(bool insecure);
+    void setInsecureController(bool insecure);
     void setInsecure(bool insecure);
     void setProxyHost(std::string proxyHost);
     void setToken(std::string token);

--- a/src/fedn.cpp
+++ b/src/fedn.cpp
@@ -144,9 +144,18 @@ std::map<std::string, std::string> FednClient::assignCombiner() {
     // Pretty print of the response
     std::cout << "Response: " << httpResponseData.dump(4) << std::endl;
 
+    if (combinerConfig["insecure"] == "true") {
+        // Concatenate host and port for insecure connection
+        std::string host = httpResponseData["host"].get<std::string>();
+        int port = httpResponseData["port"].get<int>();
+        combinerConfig["host"] = host + ":" + std::to_string(port);
+    } else {
+        // For secure connection, use the host as is
+        combinerConfig["host"] = httpResponseData["host"].get<std::string>();
+    }
+
     // Setup gRPC channel configuration
-    combinerConfig["host"] = httpResponseData["host"];
-    combinerConfig["proxy_host"] = httpResponseData["fqdn"];
+    combinerConfig["proxy_host"] = httpResponseData["fqdn"].is_null() ? "" : httpResponseData["fqdn"].get<std::string>();
     combinerConfig["token"] = httpClient->getToken();
 
     return combinerConfig;
@@ -278,7 +287,7 @@ void FednClient::setCombinerHost(std::string host) {
 }
 
 /**
- * @brief Sets the insecure mode for the FednClient.
+ * @brief Sets the insecure mode in the combiner configuration.
  *
  * This method configures the client to operate in insecure mode if the 
  * parameter is set to true.
@@ -287,8 +296,37 @@ void FednClient::setCombinerHost(std::string host) {
  *                 - true: Enable insecure mode.
  *                 - false: Disable insecure mode.
  */
-void FednClient::setInsecure(bool insecure) {
+void FednClient::setInsecureCombiner(bool insecure) {
     combinerConfig["insecure"] = insecure ? "true" : "false";
+}
+
+/**
+ * @brief Sets the insecure mode in the controller configuration.
+ *
+ * This method configures the client to operate in insecure mode for controller
+ * communications if the parameter is set to true.
+ *
+ * @param insecure A boolean value indicating whether to enable insecure mode.
+ *                 - true: Enable insecure mode.
+ *                 - false: Disable insecure mode.
+ */
+void FednClient::setInsecureController(bool insecure) {
+    controllerConfig["insecure"] = insecure ? "true" : "false";
+}
+
+/**
+ * @brief Sets the insecure mode for both combiner and controller configurations.
+ *
+ * This method configures the client to operate in insecure mode for both
+ * combiner and controller communications if the parameter is set to true.
+ *
+ * @param insecure A boolean value indicating whether to enable insecure mode.
+ *                 - true: Enable insecure mode for both combiner and controller.
+ *                 - false: Disable insecure mode for both combiner and controller.
+ */
+void FednClient::setInsecure(bool insecure) {
+    setInsecureCombiner(insecure);
+    setInsecureController(insecure);
 }
 
 /**

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -60,8 +60,14 @@ json HttpClient::assign(std::map<std::string, std::string> controllerConfig) {
     // Convert the JSON data to a string
     std::string jsonData = requestData.dump();
 
+    // Select HTTP protocol based on insecure flag
+    std::string httpProtocol = "https://";
+    if (controllerConfig["insecure"] == "true") {
+        httpProtocol = "http://";
+    }
+
     // add endpoint /add_client to the apiUrl
-    const std::string addClientApiUrl = apiUrl + "/add_client";
+    const std::string addClientApiUrl = httpProtocol + apiUrl + "/add_client";
 
     // Set libcurl options for the POST request
     curl_easy_setopt(curl, CURLOPT_URL, addClientApiUrl.c_str());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -247,12 +247,20 @@ std::map<std::string, std::string> readControllerConfig(YAML::Node config) {
     std::cout << "Reading HTTP request data from config file" << std::endl;
     std::map<std::string, std::string> controllerConfig;
 
+    // Check if insecure is in the config, else use default false
+    if (config["insecure"]) {
+        controllerConfig["insecure"] = config["insecure"].as<std::string>();
+    }
+    else {
+        controllerConfig["insecure"] = "false";
+    }
+
     // Check if there is a valid "discover_host" key in the config
     std::string apiUrl = config["discover_host"].as<std::string>();
     if (apiUrl.empty()) {
         throw std::runtime_error("Invalid discover_host.");
     }
-    controllerConfig["api_url"] = "https://" + apiUrl;
+    controllerConfig["api_url"] = apiUrl;
 
     // Check if there is a "token" key in the config file
     std::string token = "";


### PR DESCRIPTION
- Now both controllerConfig and combinerConfig have a field called "insecure".
- The value of "insecure" determines whether or not to use encryption on the connection to the controller (HTTP/HTTPS) and to the combiner (SSL cert or not).
- If controllerConfig["insecure"] then the combiner URL is assembled by concatenating "host" and "port" from the HTTP response.
- Insecure config can be set from client.yaml file or through the API functions setInsecureController (set "insecure" in controllerConfig), setInsecureCombiner (set "insecure" in combinerConfig) and setInsecure (set both).