### PR TITLE
Feature/SK-1247 | Updates Role, StatusType and LogLevel in protos

### DIFF
--- a/src/grpc.cpp
+++ b/src/grpc.cpp
@@ -25,7 +25,7 @@ using fedn::ModelStatus;
 using fedn::StatusType;
 using fedn::Client;
 using fedn::ClientAvailableMessage;
-using fedn::WORKER;
+using fedn::CLIENT;
 using fedn::Response;
 
 /**
@@ -58,7 +58,7 @@ void GrpcClient::heartBeat() {
     // Data we are sending to the server.
     Client* client = new Client();
     client->set_name(name_);
-    client->set_role(WORKER);
+    client->set_role(CLIENT);
     client->set_client_id(id_);
 
     Heartbeat request;
@@ -104,7 +104,7 @@ void GrpcClient::connectTaskStream() {
     // Data we are sending to the server.
     Client* client = new Client();
     client->set_name(name_);
-    client->set_role(WORKER);
+    client->set_role(CLIENT);
     client->set_client_id(id_);
 
     ClientAvailableMessage request;
@@ -162,7 +162,7 @@ std::string GrpcClient::downloadModel(const std::string& modelID) {
      // Set client
     Client* client = new Client();
     client->set_name(name_);
-    client->set_role(WORKER);
+    client->set_role(CLIENT);
     client->set_client_id(id_);
 
     // Pass ownership of client to protobuf message
@@ -231,7 +231,7 @@ void GrpcClient::downloadModelToFile(const std::string& modelID, const std::stri
     // Set client
     Client* client = new Client();
     client->set_name(name_);
-    client->set_role(WORKER);
+    client->set_role(CLIENT);
     client->set_client_id(id_);
 
     // Pass ownership of client to protobuf message
@@ -305,7 +305,7 @@ void GrpcClient::uploadModel(std::string& modelID, std::string& modelData) {
     // Client
     Client* client = new Client();
     client->set_name(name_);
-    client->set_role(WORKER);
+    client->set_role(CLIENT);
     client->set_client_id(id_);
 
     // Get ClientWriter from stream
@@ -384,7 +384,7 @@ void GrpcClient::uploadModelFromFile(const std::string& modelID, const std::stri
     // Client
     Client* client = new Client();
     client->set_name(name_);
-    client->set_role(WORKER);
+    client->set_role(CLIENT);
     client->set_client_id(id_);
 
     // Get ClientWriter from stream
@@ -639,7 +639,7 @@ void GrpcClient::sendModelUpdate(const std::string& modelID, std::string& modelU
     // Send model update response to server
     Client client;
     client.set_name(name_);
-    client.set_role(WORKER);
+    client.set_role(CLIENT);
     client.set_client_id(id_);
 
     
@@ -698,7 +698,7 @@ void GrpcClient::sendModelValidation(const std::string& modelID, json& metricDat
     // Send model validation response to server
     Client client;
     client.set_name(name_);
-    client.set_role(WORKER);
+    client.set_role(CLIENT);
     client.set_client_id(id_);
 
     ModelValidation validation;
@@ -756,7 +756,7 @@ void GrpcClient::sendModelPrediction(const std::string& modelID, json& predictio
     // Send model prediction response to server
     Client client;
     client.set_name(name_);
-    client.set_role(WORKER);
+    client.set_role(CLIENT);
     client.set_client_id(id_);
 
     ModelPrediction prediction;

--- a/src/protos/fedn.proto
+++ b/src/protos/fedn.proto
@@ -15,20 +15,21 @@ enum StatusType {
   MODEL_VALIDATION_REQUEST = 3;
   MODEL_VALIDATION = 4;
   MODEL_PREDICTION = 5;
+  NETWORK = 6;
+}
+
+enum LogLevel {
+      NONE = 0;
+      INFO  = 1;
+      DEBUG = 2;
+      WARNING = 3;
+      ERROR = 4;
+      AUDIT = 5;
 }
 
 message Status {
     Client sender = 1;
     string status = 2;
-
-    enum LogLevel {
-      INFO  = 0;
-      DEBUG = 1;
-      WARNING = 2;
-      ERROR = 3;
-      AUDIT = 4;
-    }
-
     LogLevel log_level = 3;
     string data = 4;
     string correlation_id = 5;

--- a/src/protos/fedn.proto
+++ b/src/protos/fedn.proto
@@ -149,10 +149,10 @@ message ClientList {
 }
 
 enum Role {
-  WORKER = 0;
-  COMBINER = 1;
-  REDUCER = 2;
-  OTHER = 3;
+  OTHER = 0;
+  CLIENT = 1;
+  COMBINER = 2;
+  REDUCER = 3;
 }
 
 message Client {


### PR DESCRIPTION
* Changed the enum in fedn.proto to reflect changes from [Feature/SK-1246](https://github.com/scaleoutsystems/fedn/commit/c416b72a683360a2f50e34e7b8b2ee7963b8fd06#diff-22f72a602c13a0c18ffe7a97a5a54d8b92294b62d14bd9bbe7eb509b5529a7e1R158) in fedn repo
* Added StatusType NETWORK and moved enum LogLevel outside of Status message to reflect changes from [Bugfix/SK-1241](https://github.com/scaleoutsystems/fedn/pull/766) in fedn repo
* Replaced all occurrences of _WORKER_ with _CLIENT_ (only in grpc.cpp)
