### PR TITLE
Fix/SK-000 | remove std::optional

### DIFF
--- a/include/fednlib/grpc.h
+++ b/include/fednlib/grpc.h
@@ -65,7 +65,7 @@ public:
     void setName(const std::string& name);
     void setId(const std::string& id);
     void setChunkSize(std::size_t chunkSize);
-    bool logMetrics(const std::map<std::string, float>& metrics, const std::optional<int> step=std::nullopt, const bool commit=true);
+    bool logMetrics(const std::map<std::string, float>& metrics, const int* step=nullptr, const bool commit=true);
     bool sendModelMetrics(const std::map<std::string, float>& metrics, 
         const std::string& name, 
         const std::string& client_id, 

--- a/src/grpc.cpp
+++ b/src/grpc.cpp
@@ -889,10 +889,10 @@ void sendIntervalHeartBeat(GrpcClient* client, int intervalSeconds) {
 }
 
 
-bool GrpcClient::logMetrics(const std::map<std::string, float>& metrics, const std::optional<int> step, const bool commit){
+bool GrpcClient::logMetrics(const std::map<std::string, float>& metrics, const int* step, const bool commit){
     // Add step and commit information if provided
-    if (step.has_value()) {
-        loggingContext.setStep(step.value());
+    if (step != nullptr) {
+        loggingContext.setStep(*step);
     }
     std::string roundId = loggingContext.getRoundId();
     std::string modelId = loggingContext.getModelId();


### PR DESCRIPTION
std::optional feature requires c++ standard 17. We don't want to introduce this standard requirement at this time.

OSB I have tested connection to fedn 0.30 backend on studio. However, I don't know if this breaks logging features (Attributes, metrics etc)